### PR TITLE
fix: 打开数据库成功时不显示错误信息

### DIFF
--- a/main.js
+++ b/main.js
@@ -87,12 +87,14 @@ async function onLoad() {
         valueEncoding: "json"
     });
 
-    db.open((e) =>
-        output(
-            "打开数据库失败，可能是QQ进程未完全退出。请查看下面详细错误信息中的cause部分：",
-            e
-        )
-    );
+    db.open((e) => {
+        if(e!==undefined && e!==null) { 
+            output(
+                "打开数据库失败，可能是QQ进程未完全退出。请查看下面详细错误信息中的cause部分：",
+                e
+            )
+        }
+    });
 
     ipcMain.handle("LiteLoader.anti_recall.clearDb", async (event, message) => {
         dialog


### PR DESCRIPTION
### 问题
- 实测在Linux下使用此插件并启用数据库保存时, 每一次启动QQNT均会出现下图的提示:
  ![image](https://github.com/xh321/LiteLoaderQQNT-Anti-Recall/assets/102411014/52bc13c9-289d-420f-9599-9319fd0e4304)
- 而实际上数据库打开成功.
### 解决方案
- 在原本的代码上进行修改: `e` 不为 `undefined` 或 `null` 时才 output
### 结论
<details>
<summary>当确实失败时才会显示 & Please merge this PR!</summary>

![image](https://github.com/xh321/LiteLoaderQQNT-Anti-Recall/assets/102411014/1680478f-0656-4e12-9ffd-ce7c877a6b2b)

</details>
