### PR TITLE
修复: 撤回阴影显示问题2

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
     "name": "防撤回",
     "slug": "anti_recall",
     "description": "防止QQNT撤回消息",
-    "version": "0.2.41",
+    "version": "0.2.43",
     "icon": "./icon.png",
     "authors": [
         {
@@ -16,7 +16,7 @@
         "repo": "xh321/LiteLoaderQQNT-Anti-Recall",
         "branch": "master",
         "release": {
-            "tag": "0.2.41",
+            "tag": "0.2.43",
             "file": "qq-anti-recall.zip"
         }
     },

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
     "name": "防撤回",
     "slug": "anti_recall",
     "description": "防止QQNT撤回消息",
-    "version": "0.2.42",
+    "version": "0.2.41",
     "icon": "./icon.png",
     "authors": [
         {
@@ -16,7 +16,7 @@
         "repo": "xh321/LiteLoaderQQNT-Anti-Recall",
         "branch": "master",
         "release": {
-            "tag": "0.2.42",
+            "tag": "0.2.41",
             "file": "qq-anti-recall.zip"
         }
     },

--- a/renderer.js
+++ b/renderer.js
@@ -459,7 +459,6 @@ async function patchCss() {
   stylee.id = "anti-recall-css";
 
   var sHtml = `   .message-content__wrapper {
-                    padding: 10px 10px 10px 10px;
                     color: var(--bubble_guest_text);
                     display: flex;
                     grid-row-start: content;
@@ -468,8 +467,7 @@ async function patchCss() {
                     grid-column-end: content;
                     max-width: -webkit-fill-available;
                     min-height: 38px;
-                    overflow-x: hidden;
-                    overflow-y: hidden;
+                    overflow: visible !important;
                     border-radius: 10px; 
                   }
 

--- a/renderer.js
+++ b/renderer.js
@@ -459,6 +459,7 @@ async function patchCss() {
   stylee.id = "anti-recall-css";
 
   var sHtml = `   .message-content__wrapper {
+                    padding: 10px 10px 10px 10px;
                     color: var(--bubble_guest_text);
                     display: flex;
                     grid-row-start: content;


### PR DESCRIPTION
### 问题:
- [0.2.42](https://github.com/xh321/LiteLoaderQQNT-Anti-Recall/releases/tag/0.2.42)版本更新移除Padding导致再现 #73  中的问题。

![7A268514902BC4872CF4CCEA0E20D5DC](https://github.com/user-attachments/assets/62882c4a-52e9-417f-ba27-ada3df4458e8)

### 解决:
- 移除上述Padding。
- 修改```overflow```为超出部分显示。

![image](https://github.com/user-attachments/assets/cca18c4c-3be3-4438-9aa6-5149fa4cadaa)

### 环境:
- Windows 11 Pro
- QQNT 9.9.12-26466
- LiteLoader 1.2.0
- LiteLoaderQQNT-Anti-Recall 0.2.42